### PR TITLE
add share clipboard for mac

### DIFF
--- a/.tmux.conf
+++ b/.tmux.conf
@@ -74,6 +74,10 @@ bind-key -t vi-copy V select-line
 bind-key -t vi-copy y copy-selection
 # Y で１行ヤンク
 bind-key -t vi-copy Y copy-line
+# macのクリップボードにもコピー
+bind-key -t vi-copy y copy-pipe "reattach-to-user-namespace pbcopy"
+bind-key -t vi-copy Y copy-line "reattach-to-user-namespace pbcopy"
+set-option -g default-command "reattach-to-user-namespace -l bash"
 # prefix p でペースト
 bind-key p paste-buffer
 # バッファから選択してペースト


### PR DESCRIPTION
mac限定ですが、tmuxのコピーがmacのクリップボードと連携してくれます。
素晴らしいですよね。いかがでしょうか？

使用するにはreattach-to-user-namespaceをインストールする必要があります。
$ brew install reattach-to-user-namespace

参考:http://qiita.com/upinetree/items/cd80bc7865c52091be10
